### PR TITLE
feat: prevent start flag and debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ https://github.com/helium/gateway-rs/releases) (built from the [GitHub source](h
 ## Environment variables
 `REGION_OVERRIDE` and `I2C_DEVICE` are used to load the correct settings for the gateway. All settings override will continue to work as documented by upstream [gateway-rs](https://github.com/helium/gateway-rs).
 
+`PREVENT_START_GATEWAYRS` can be set to `1` to prevent the miner from starting.
+This is helpful for debugging the miner manually.
+
 ## Mr Bump
 
 [Mr Bump](https://github.com/mr-bump) is a GitHub bot we created to automate some tasks related to the miner software. This includes updating the miner to the latest GA (and tagging / releasing this update) as well as updating the necessary `docker-compose.yml` files.

--- a/nebra-gateway-settings-defaults.toml
+++ b/nebra-gateway-settings-defaults.toml
@@ -5,7 +5,7 @@ listen = "0.0.0.0:1680"
 
 [log]
 method = "stdio"
-level = "info"
+level = "debug"
 timestamp = false
 
 [update]

--- a/start-gatewayrs.sh
+++ b/start-gatewayrs.sh
@@ -41,11 +41,16 @@ then
   export GW_REGION="${REGION_OVERRIDE}"
 fi
 
-# NOTE:: this should ultimately move to pktfwd container.
+# NOTE: this should ultimately move to pktfwd container.
 # the local rpc should is capable of providing this information
 /opt/nebra-gatewayrs/gen-region.sh &
 
-# there is a systemd/sysv script for this service in the deb package
-# it doesn't make much sense to use it in the container
-/usr/bin/helium_gateway -c /etc/helium_gateway server
-
+prevent_start="${PREVENT_START_GATEWAYRS:-0}"
+if [ "$prevent_start" = 1 ]; then
+    echo "gatewayrs will not be started. PREVENT_START_GATEWAYRS=1"
+    while true; do sleep 1000; done
+else
+    # there is a systemd/sysv script for this service in the deb package
+    # it doesn't make much sense to use it in the container
+    /usr/bin/helium_gateway -c /etc/helium_gateway server
+fi


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/179
- Summary: More verbose logging and added env var flag to prevent miner from starting

**How**
- Use stdio logging. syslog logging causes miner to crash
```
# /usr/bin/helium_gateway -c /etc/helium_gateway server
thread 'main' panicked at 'syslog drain: Custom { kind: Other, error: "Initialization" }', src/main.rs:53:18
```
- `PREVENT_START_GATEWAYRS` can be set to `1` to prevent the miner from starting. This is helpful for debugging the miner manually.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names