### PR TITLE
fix: install from requirements.txt instead

### DIFF
--- a/.github/workflows/docker-lints.yml
+++ b/.github/workflows/docker-lints.yml
@@ -6,8 +6,8 @@ jobs:
   docker-lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Lint Dockerfile
-      uses: brpaz/hadolint-action@v1.2.1
+      uses: hadolint/hadolint-action@v3.1.0
       with:
         dockerfile: Dockerfile

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,56 @@
+---
+###########################
+###########################
+## Linter GitHub Actions ##
+###########################
+###########################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+  pull_request:
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_BASH: true
+          VALIDATE_JSON: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -6,9 +6,9 @@ jobs:
   security-audit:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Run bandit against code base 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run ShellCheck against code base
       uses: ludeeus/action-shellcheck@master
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM quay.io/team-helium/miner:gateway-v1.0.0 AS runner
 
+WORKDIR /opt/nebra-gatewayrs
+COPY requirements.txt requirements.txt
+
 # grpcio has to be installed from cache
 # hadolint ignore=DL3042,DL3018
-RUN mkdir -p /opt/nebra-gatewayrs && \
-    apk add --no-cache python3=3.10.11-r0 py3-grpcio==1.50.1-r0 gcompat && \
+RUN apk add --no-cache python3=3.10.11-r0 py3-grpcio==1.50.1-r0 gcompat && \
     python3 -m ensurepip && \
-    pip3 install grpcio==1.50.1 && \
-    pip3 install hm-pyhelper==0.14.5 && \
+    pip3 install --no-cache-dir -r requirements.txt && \
     cp /etc/helium_gateway/settings.toml /etc/helium_gateway/settings.toml.orig
-WORKDIR /opt/nebra-gatewayrs
 
 ARG SYSTEM_TIMEZONE=Europe/London
 ARG GATEWAY_RS_RELEASE=v1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-# These two are required but installed externally due to compatibility issues
-# grpcio==1.50.1
-# hm-pyhelper==0.14.4
+grpcio==1.50.1
+hm-pyhelper==0.14.5


### PR DESCRIPTION
**Issue**

- Link:
- Summary: fix: install from requirements.txt instead

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

- move packages to requirements.txt but keep installing from cache
- remove pip cache after installation complete to slim down layer
- using workdir there is no need for mkdir (it does mkdir and cd if directory doesnt exist)
- bump action versions to latest to remove nodejs warnings
- add linter

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names