### PR TITLE
feat: wait for diagnostics to load

### DIFF
--- a/start-gatewayrs.sh
+++ b/start-gatewayrs.sh
@@ -16,6 +16,13 @@ if [ -n "${REGION_OVERRIDE+x}" ]; then
   export GW_REGION="${REGION_OVERRIDE}"
 fi
 
+# Wait for the diagnostics app to be loaded
+until wget -q -T 10 -O - http://diagnostics:80/initFile.txt > /dev/null 2>&1
+do
+  echo "Diagnostics container not ready. Going to sleep."
+  sleep 10
+done
+
 # This script runs in the background and checks the region every second.
 # It would generate a region file if the gateway is not giving any error
 # and returns a region other than the impossible default, EU433.


### PR DESCRIPTION
we need to wait for diagnostics to load, to ensure key is provisioned in manufacturing before starting miner

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names