### PR TITLE
Removed host networking necessity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM quay.io/team-helium/miner:gateway-"$GATEWAY_RS_RELEASE" AS runner
 ARG GATEWAY_RS_RELEASE
 ENV GATEWAY_RS_RELEASE $GATEWAY_RS_RELEASE
 
+ENV GW_API "0.0.0.0:4467"
+ENV GW_LISTEN "0.0.0.0:1680"
+
 WORKDIR /opt/nebra-gatewayrs
 COPY requirements.txt requirements.txt
 

--- a/gen-region.sh
+++ b/gen-region.sh
@@ -7,7 +7,7 @@ done
 
 REGIONDATA=$(helium_gateway info region | grep "region" | cut -d ":" -f2 | tr -d " ,\"")
 
-while [ "$REGIONDATA" = "EU433" ] || [ "$REGIONDATA" = "" ]; do
+while [ "$REGIONDATA" = "EU433" ] || [ "$REGIONDATA" = "" ] || [ "$REGIONDATA" = "null" ]; do
     sleep 1
     REGIONDATA=$(helium_gateway info region | grep "region" | cut -d ":" -f2 | tr -d " ,\"")
 done

--- a/start-gatewayrs.sh
+++ b/start-gatewayrs.sh
@@ -24,13 +24,6 @@ if [ -n "${REGION_OVERRIDE+x}" ]; then
   export GW_REGION="${REGION_OVERRIDE}"
 fi
 
-# Wait for the diagnostics app to be loaded
-until wget -q -T 10 -O - http://diagnostics:80/initFile.txt > /dev/null 2>&1
-do
-  echo "Diagnostics container not ready. Going to sleep."
-  sleep 10
-done
-
 # This script runs in the background and checks the region every second.
 # It would generate a region file if the gateway is not giving any error
 # and returns a region other than the impossible default, EU433.


### PR DESCRIPTION
With the release of gateway-rs 1.0.1, we're now able to connect to API end point outside of the container. Hence removing host networking.

Also removed diagnostics check from `start-gatewayrs.sh` as it's breaking the dependency tree. Diagnostics is already depends on hm-gatewayrs. No need to create a dangerous reverse dependency as gateway-rs is just fine without diagnostics.

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names