### PR TITLE
Fixed: i2c-tools package is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt requirements.txt
 
 # grpcio has to be installed from cache
 # hadolint ignore=DL3042,DL3018
-RUN apk add --no-cache python3=3.10.11-r0 py3-grpcio==1.50.1-r0 gcompat && \
+RUN apk add --no-cache python3=3.10.11-r0 py3-grpcio=1.50.1-r0 gcompat=1.1.0-r0 i2c-tools=4.3-r1 && \
     python3 -m ensurepip && \
     pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
**Issue**
Some SB miners are having issues due to missing i2c-tools package.

https://nebraltd.atlassian.net/browse/NEBD-246

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names